### PR TITLE
Adjust configuration to text

### DIFF
--- a/src/Config/auth.php
+++ b/src/Config/auth.php
@@ -19,7 +19,7 @@ return [
     |
     */
 
-    'username_attribute' => ['email' => 'mail'],
+    'username_attribute' => ['username' => 'samaccountname'],
 
     /*
     |--------------------------------------------------------------------------

--- a/tests/AdldapTest.php
+++ b/tests/AdldapTest.php
@@ -59,7 +59,7 @@ class AdldapTest extends FunctionalTestCase
         Adldap::shouldReceive('users')->once()->andReturn($mockedUsers);
         Adldap::shouldReceive('authenticate')->once()->andReturn(true);
 
-        $this->assertTrue(Auth::attempt(['email' => 'jdoe@email.com', 'password' => '12345']));
+        $this->assertTrue(Auth::attempt(['username' => 'jdoe', 'password' => '12345']));
 
         $user = Auth::user();
 
@@ -100,7 +100,7 @@ class AdldapTest extends FunctionalTestCase
 
         Adldap::shouldReceive('users')->once()->andReturn($mockedUsers);
 
-        $this->assertFalse(Auth::attempt(['email' => 'jdoe@email.com', 'password' => '12345']));
+        $this->assertFalse(Auth::attempt(['username' => 'jdoe', 'password' => '12345']));
     }
 
     public function testAuthFailsWhenUserFound()
@@ -127,7 +127,7 @@ class AdldapTest extends FunctionalTestCase
         Adldap::shouldReceive('users')->once()->andReturn($mockedUsers);
         Adldap::shouldReceive('authenticate')->once()->andReturn(false);
 
-        $this->assertFalse(Auth::attempt(['email' => 'jdoe@email.com', 'password' => '12345']));
+        $this->assertFalse(Auth::attempt(['username' => 'jdoe', 'password' => '12345']));
     }
 
     public function testCredentialsKeyDoesNotExist()


### PR DESCRIPTION
The text and the configuration didn't match.
Also it didn't work because `login_attribute` is set to
`samaccountname`.

This pull request changes the default value.