### PR TITLE
Fix for Lumen

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,8 +6,7 @@
     "type": "project",
     "require": {
         "php": ">=5.4.16",
-        "adldap2/adldap2": "5.2.*",
-        "laravel/framework": "5.*"
+        "adldap2/adldap2": "5.2.*"
     },
     "require-dev": {
         "orchestra/testbench": "~3.0",


### PR DESCRIPTION
Update Composer file to remove Laravel as a requirement so that this project can be used with Laravel as well as Lumen (requiring Laravel adds the Laravel framework and removes Illuminate as a requirement, which means Lumen no longer functions).