### PR TITLE
Add php 7.0 into travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,18 @@ php:
   - 5.4
   - 5.5
   - 5.6
+  - 7.0
+  - hhvm
 
 before_install: echo "extension=ldap.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
 
 before_script:
   - travis_retry composer self-update
   - travis_retry composer install --prefer-source --no-interaction --dev
+
+matrix:
+ allow_failures:
+   - php: 7.0
+   - php: hhvm
 
 script: phpunit


### PR DESCRIPTION
travis bump to newest version of php. Allows for failures.