### PR TITLE
Add the ability to enable/disable synchronisation with the database

### DIFF
--- a/src/AdldapAuthUserProvider.php
+++ b/src/AdldapAuthUserProvider.php
@@ -76,7 +76,9 @@ class AdldapAuthUserProvider extends EloquentUserProvider
         // Check if we already have an authenticated AD user.
         if ($this->user instanceof User) {
             // We'll save the model in case of changes.
-            $this->saveModel($user);
+            if(Config::get('adldap_auth.database_sync')) {
+                $this->saveModel($user);
+            }
 
             return true;
         }

--- a/src/Config/auth.php
+++ b/src/Config/auth.php
@@ -217,4 +217,18 @@ return [
 
     ],
 
+    /*
+    |--------------------------------------------------------------------------
+    | Database Sync
+    |--------------------------------------------------------------------------
+    |
+    | Enable/Disable the database synchronizing
+    |
+    | If this option is true, users will be created in users table in database.
+    | If this options is false, users will be only retrieve from ldap servers.
+    |
+    */
+
+    'database_sync' => env('ADLDAP_DATABASE_SYNC', true),
+
 ];

--- a/src/Middleware/WindowsAuthenticate.php
+++ b/src/Middleware/WindowsAuthenticate.php
@@ -73,7 +73,9 @@ class WindowsAuthenticate
                     $model = $this->getModelFromAdldap($user, str_random());
 
                     // Save model in case of changes.
-                    $this->saveModel($model);
+                    if(Config::get('adldap_auth.database_sync')) {
+                        $this->saveModel($model);
+                    }
 
                     // Manually log the user in.
                     $this->auth->login($model);


### PR DESCRIPTION
According with the issue #143

A setting `database_sync` was added in `adldap_auth.php` file. This setting is checked on each call to `saveModel()` function.
This parameter could be changed in `.env` file with `ADLDAP_DATABASE_SYNC` header.