### PR TITLE
This allows Adldap2-Laravel to work with Lumen

### DIFF
--- a/src/AdldapServiceProvider.php
+++ b/src/AdldapServiceProvider.php
@@ -9,7 +9,7 @@ use Adldap\Schemas\SchemaInterface;
 use Adldap\Connections\ConnectionInterface;
 use Adldap\Laravel\Exceptions\ConfigurationMissingException;
 use Illuminate\Support\ServiceProvider;
-use Illuminate\Contracts\Foundation\Application;
+use Illuminate\Container\Container;
 
 class AdldapServiceProvider extends ServiceProvider
 {
@@ -37,7 +37,7 @@ class AdldapServiceProvider extends ServiceProvider
     public function register()
     {
         // Bind the Adldap instance to the IoC
-        $this->app->singleton('adldap', function (Application $app) {
+        $this->app->singleton('adldap', function (Container $app) {
             $config = $app->make('config')->get('adldap');
 
             // Verify configuration exists.

--- a/src/AdldapServiceProvider.php
+++ b/src/AdldapServiceProvider.php
@@ -20,6 +20,10 @@ class AdldapServiceProvider extends ServiceProvider
      */
     public function boot()
     {
+        if ($this->isLumen()) {
+            return;
+        }
+
         $config = __DIR__.'/Config/config.php';
 
         $this->publishes([
@@ -120,5 +124,15 @@ class AdldapServiceProvider extends ServiceProvider
     protected function newProvider($configuration = [], ConnectionInterface $connection = null, SchemaInterface $schema = null)
     {
         return new Provider($configuration, $connection, $schema);
+    }
+
+    /**
+     * Is this a Lumen application?
+     *
+     * @return bool
+     */
+    protected function isLumen()
+    {
+        return str_contains($this->app->version(), 'Lumen');
     }
 }


### PR DESCRIPTION
By binding Adldap2 to a common interface shared by both Laravel and Lumen this allows the library to work with Lumen out of the box.

NB. Lumen needs additional configuration with a manually added config file.