### PR TITLE
Add composer vendor and composer.lock to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+composer.lock
+vendor/


### PR DESCRIPTION
Prevent accidental stage / commit of composer.lock or vendor files. 