### PR TITLE
Fix link to syncing passwords doc in readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -39,7 +39,7 @@ To use Adldap2-Laravel, your application and server must meet the following requ
     * [Binding to the User Model](docs/auth/binding.md)
     * [Login Fallback](docs/auth/fallback.md)
     * [Single Sign On (SSO) Middleware](docs/auth/middleware.md)
-    * [Password Synchronization](docs/auth/syncing/#password-synchronization)
+    * [Password Synchronization](docs/auth/syncing.md#password-synchronization)
     * [Importing Users](docs/importing.md)
     * [Developing without an AD connection](docs/auth/fallback.md#developing-locally-without-an-ad-connection)
 


### PR DESCRIPTION
The current link to sync passwords is dead. This commit fixes the issue and corrects the documentation. 