### PR TITLE
Fix small typo

### DIFF
--- a/docs/auth/scopes.md
+++ b/docs/auth/scopes.md
@@ -31,7 +31,7 @@ class AccountingScope implements ScopeInterface
     /**
      * Apply the scope to a given LDAP query builder.
      *
-     * @param Builer $builder
+     * @param Builer $query
      *
      * @return void
      */

--- a/docs/auth/scopes.md
+++ b/docs/auth/scopes.md
@@ -40,7 +40,7 @@ class AccountingScope implements ScopeInterface
         // The distinguished name of our LDAP group.
         $accounting = 'cn=Accounting,ou=Groups,dc=acme,dc=org';
         
-        $query->whereMemeberOf($accouning);
+        $query->whereMemeberOf($accounting);
     }
 }
 ```


### PR DESCRIPTION
Fixed a small typo: `accouning` -> `accounting`.