### PR TITLE
Fix spelling in scopes.md

### DIFF
--- a/docs/auth/scopes.md
+++ b/docs/auth/scopes.md
@@ -31,7 +31,7 @@ class AccountingScope implements ScopeInterface
     /**
      * Apply the scope to a given LDAP query builder.
      *
-     * @param Builer $query
+     * @param Builder $query
      *
      * @return void
      */


### PR DESCRIPTION
In the comment block, "Builder" was misspelled as "Builer".