### PR TITLE
Bypass import confirmation with --no-interaction

### DIFF
--- a/src/Commands/Import.php
+++ b/src/Commands/Import.php
@@ -77,11 +77,13 @@ class Import extends Command
             $this->info("Found {$count} user(s).");
         }
 
-        if ($this->confirm('Would you like to display the user(s) to be imported / synchronized?')) {
+        $interactive = $this->input->isInteractive();
+
+        if (!$interactive || $this->confirm('Would you like to display the user(s) to be imported / synchronized?')) {
             $this->display($users);
         }
 
-        if ($this->confirm('Would you like these users to be imported / synchronized?')) {
+        if (!$interactive || $this->confirm('Would you like these users to be imported / synchronized?')) {
             $imported = $this->import($users);
 
             $this->info("\nSuccessfully imported / synchronized {$imported} user(s).");


### PR DESCRIPTION
Right now, if the user tries to run with --no-interaction, the script will not import the users.
With this change, the script will import the users if --no-interaction is specified.