### PR TITLE
Can set auto_connect from .env file

### DIFF
--- a/src/Config/config.php
+++ b/src/Config/config.php
@@ -34,7 +34,7 @@ return [
             |
             */
 
-            'auto_connect' => true,
+            'auto_connect' => env('ADLDAP_AUTO_CONNECT', true),
 
             /*
             |--------------------------------------------------------------------------


### PR DESCRIPTION
You can set the option auto_connect to true/false from the Laravel .env file with ADLDAP_AUTO_CONNECT=true