### PR TITLE
Fix namespace

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     "extra": {
         "laravel": {
             "providers": [
-                "Adldap\\Adldap\\AdldapServiceProvider"
+                "Adldap\\Laravel\\AdldapServiceProvider"
             ],
             "aliases": {
                 "Adldap": "Adldap\\Laravel\\Facades\\Adldap"


### PR DESCRIPTION
Thanks to @mazedlx and his pull request #342 Adldap2-Laravel has now Laravel 5.5 package automatic discovery support.

There is just a little error in the configuration, the namespace of the provider is wrong.
My PR fixes that issue.