### PR TITLE
[v3.0] Allow imports to be done with "no-interaction"

### DIFF
--- a/src/Commands/Import.php
+++ b/src/Commands/Import.php
@@ -77,11 +77,14 @@ class Import extends Command
             $this->info("Found {$count} user(s).");
         }
 
-        if ($this->confirm('Would you like to display the user(s) to be imported / synchronized?')) {
+        $interactive = ! $this->option('no-interaction');
+
+        if (!$interactive || $this->confirm('Would you like to display the user(s) to be imported / synchronized?')) {
             $this->display($users);
         }
 
-        if ($this->confirm('Would you like these users to be imported / synchronized?', $default = true)) {
+        if (!$interactive || $this->confirm('Would you like these users to be imported / synchronized?',
+                $default = true)) {
             $imported = $this->import($users);
 
             $this->info("Successfully imported / synchronized {$imported} user(s).");


### PR DESCRIPTION
This re-implements #284 (#344) which makes it possible to run `adldap:import` unattended (e.g. cron / scheduler) For some reason the change done in #284 is missing from `v3.0` and `dev-master`

This is for` v3.0` since the importer in `dev-master` has changed (see #435 for that)