### PR TITLE
Fixes #448: Only generate a random password if we don't have one set

### DIFF
--- a/src/Auth/DatabaseUserProvider.php
+++ b/src/Auth/DatabaseUserProvider.php
@@ -138,17 +138,24 @@ class DatabaseUserProvider extends Provider
                     // We'll check if we've been given a password and that
                     // syncing password is enabled. Otherwise we'll
                     // use a random 16 character string.
+
+                    $password = null;
                     if ($this->isSyncingPasswords()) {
                         $password = $credentials['password'];
                     } else {
-                        $password = str_random();
+                        if(null === $model->password || empty($model->password)) {
+                            // password unset
+                            $password = str_random();
+                        }
                     }
 
                     // If the model has a set mutator for the password then we'll
                     // assume that we're using a custom encryption method for
                     // passwords. Otherwise we'll bcrypt it normally.
-                    $model->password = $model->hasSetMutator('password') ?
-                        $password : bcrypt($password);
+                    if(null !== $password) {
+                        $model->password = $model->hasSetMutator('password') ?
+                            $password : bcrypt($password);
+                    }
 
                     // All of our validation rules have passed and we can
                     // finally save the model in case of changes.

--- a/src/Commands/Import.php
+++ b/src/Commands/Import.php
@@ -112,11 +112,14 @@ class Import extends Command
                 // Import the user and retrieve it's model.
                 $model = $this->getImporter()->run($user, $this->model(), $credentials);
 
-                $password = str_random();
+                // Only set a new password if we are creating a new user
+                if (!isset($model->password)) {
+                    $password = str_random();
 
-                // Set the models password.
-                $model->password = $model->hasSetMutator('password') ?
-                    $password : bcrypt($password);
+                    // Set the models password.
+                    $model->password = $model->hasSetMutator('password') ?
+                        $password : bcrypt($password);
+                }
 
                 // Save the returned model.
                 $this->save($user, $model);

--- a/src/Commands/Import.php
+++ b/src/Commands/Import.php
@@ -113,7 +113,7 @@ class Import extends Command
                 $model = $this->getImporter()->run($user, $this->model(), $credentials);
 
                 // Only set a new password if we are creating a new user
-                if (!isset($model->password)) {
+                if (!isset($model->password) || empty($model->password)) {
                     $password = str_random();
 
                     // Set the models password.


### PR DESCRIPTION
This fixes #448 where a random password would be generated every import / user login if `password_sync` is disabled. This would result in an unnecessary change to the userdata (and timestamps).

Note: This uses the import command from the `v3.0` branch, which is currently lacking the `no-interaction` fix committed earlier.