### PR TITLE
Update SyncPassword.php

### DIFF
--- a/src/Commands/SyncPassword.php
+++ b/src/Commands/SyncPassword.php
@@ -145,9 +145,9 @@ class SyncPassword
     /**
      * Retrieves the password column to use.
      *
-     * @return string
+     * @return string|null
      */
-    protected function column() : string
+    protected function column()
     {
         return Config::get('adldap_auth.passwords.column', 'password');
     }


### PR DESCRIPTION
The config states that `column` should be set to null if there is no password column. Since PHP 7.0 doesn't support nullable return types, we can't type hint the return from this method.

Config reference:
https://github.com/Adldap2/Adldap2-Laravel/blob/3e118ce82c7fb8d90d7fedfe331c825a5812e904/src/Config/auth.php#L214