### PR TITLE
Added 'usesAdldapProvider' method to the 'BindsLdapUserModel' listener

### DIFF
--- a/src/Listeners/BindsLdapUserModel.php
+++ b/src/Listeners/BindsLdapUserModel.php
@@ -2,10 +2,12 @@
 
 namespace Adldap\Laravel\Listeners;
 
+use Adldap\Laravel\Auth\Provider;
 use Adldap\Laravel\Facades\Resolver;
 use Adldap\Laravel\Traits\HasLdapUser;
 use Illuminate\Auth\Events\Authenticated;
 use Illuminate\Contracts\Auth\Authenticatable;
+use Illuminate\Support\Facades\Auth;
 
 class BindsLdapUserModel
 {
@@ -18,11 +20,21 @@ class BindsLdapUserModel
      */
     public function handle(Authenticated $event)
     {
-        if ($this->canBind($event->user)) {
+        if ($this->usesAdldapProvider() && $this->canBind($event->user)) {
             $event->user->setLdapUser(
                 Resolver::byModel($event->user)
             );
         }
+    }
+
+    /**
+     * Determines if the Auth Provider is an instance of the Adldap Provider.
+     *
+     * @return bool
+     */
+    protected function usesAdldapProvider() : bool
+    {
+        return Auth::getProvider() instanceof Provider;
     }
 
     /**

--- a/tests/DatabaseTestCase.php
+++ b/tests/DatabaseTestCase.php
@@ -3,9 +3,9 @@
 namespace Adldap\Laravel\Tests;
 
 use Adldap\Connections\Ldap;
-use Adldap\Schemas\ActiveDirectory;
-use Adldap\Laravel\Tests\Models\User;
 use Adldap\Laravel\Auth\DatabaseUserProvider;
+use Adldap\Laravel\Tests\Models\User;
+use Adldap\Schemas\ActiveDirectory;
 use Illuminate\Support\Facades\Schema;
 
 class DatabaseTestCase extends TestCase
@@ -58,6 +58,10 @@ class DatabaseTestCase extends TestCase
         $app['config']->set('auth.providers', [
             'adldap' => [
                 'driver' => 'adldap',
+                'model'  => User::class,
+            ],
+            'users'  => [
+                'driver' => 'eloquent',
                 'model'  => User::class,
             ],
         ]);

--- a/tests/EloquentAuthenticateTest.php
+++ b/tests/EloquentAuthenticateTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Adldap\Laravel\Tests;
+
+use Adldap\Laravel\Commands\Import;
+use Adldap\Laravel\Facades\Resolver;
+use Adldap\Laravel\Tests\Models\User;
+use Illuminate\Support\Facades\Auth;
+
+class EloquentAuthenticateTest extends DatabaseTestCase
+{
+    /** @test */
+    public function it_doenst_set_the_ldap_user_if_the_auth_provider_is_not_ldap()
+    {
+        $this->app['config']->set('auth.guards.web.provider', 'users');
+
+        $user = $this->makeLdapUser([
+            'cn'                => 'John Doe',
+            'userprincipalname' => 'jdoe@email.com',
+        ]);
+
+        $importer = new Import($user, new User());
+
+        $model = $importer->handle();
+
+        Resolver::spy();
+        Resolver::shouldNotReceive('byModel');
+
+        Auth::login($model);
+    }
+}


### PR DESCRIPTION
This new method check wether the Auth provider is an Adldap Provider. This allows you to use the same User model (which uses the `HasLdapUser` trait) with both the `adldap` and `eloquent` driver.