### PR TITLE
Clarify documentation on admin prefix/suffix

### DIFF
--- a/src/Config/config.php
+++ b/src/Config/config.php
@@ -177,9 +177,6 @@ return [
                 | This option allows you to set a different account prefix and suffix
                 | for your configured administrator account upon binding.
                 |
-                | If left empty or set to `null`, your `account_prefix` and
-                | `account_suffix` options above will be used.
-                |
                 */
 
                 'admin_account_prefix' => env('ADLDAP_ADMIN_ACCOUNT_PREFIX', ''),


### PR DESCRIPTION
With changes in Adldap2 v4.0, the bindAsAdministrator function explicitly uses the admin_account_prefix and admin_account_suffix configuration variables and does not append the normal account prefix/suffix if empty.