### PR TITLE
DatabaseUserProvider implements DatabaseUserProviderInterface

### DIFF
--- a/src/AdldapAuthServiceProvider.php
+++ b/src/AdldapAuthServiceProvider.php
@@ -14,6 +14,7 @@ use Illuminate\Support\ServiceProvider;
 use Illuminate\Contracts\Hashing\Hasher;
 use Illuminate\Auth\Events\Login;
 use Illuminate\Auth\Events\Authenticated;
+use Adldap\Laravel\Contracts\DatabaseUserProviderInterface;
 
 class AdldapAuthServiceProvider extends ServiceProvider
 {
@@ -93,7 +94,7 @@ class AdldapAuthServiceProvider extends ServiceProvider
         // The DatabaseUserProvider has some extra dependencies needed,
         // so we will validate that we have them before
         // constructing a new instance.
-        if ($provider == DatabaseUserProvider::class) {
+        if (array_key_exists(DatabaseUserProviderInterface::class, class_implements($provider))) {
             $model = array_get($config, 'model');
 
             if (!$model) {

--- a/src/Auth/DatabaseUserProvider.php
+++ b/src/Auth/DatabaseUserProvider.php
@@ -18,8 +18,9 @@ use Illuminate\Auth\EloquentUserProvider;
 use Illuminate\Contracts\Hashing\Hasher;
 use Illuminate\Contracts\Auth\UserProvider;
 use Illuminate\Contracts\Auth\Authenticatable;
+use Adldap\Laravel\Contracts\DatabaseUserProviderInterface;
 
-class DatabaseUserProvider extends Provider
+class DatabaseUserProvider extends Provider implements DatabaseUserProviderInterface
 {
     /**
      * The hasher implementation.

--- a/src/Contracts/DatabaseUserProviderInterface.php
+++ b/src/Contracts/DatabaseUserProviderInterface.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Adldap\Laravel\Contracts;
+
+use Adldap\Models\User;
+use Illuminate\Auth\EloquentUserProvider;
+use Illuminate\Contracts\Hashing\Hasher;
+use Illuminate\Contracts\Auth\UserProvider;
+use Illuminate\Contracts\Auth\Authenticatable;
+
+interface DatabaseUserProviderInterface
+{
+    /**
+     * Constructor.
+     *
+     * @param Hasher $hasher
+     * @param string $model
+     */
+    public function __construct(Hasher $hasher, $model);
+
+    /**
+     * Retrieve a user by their unique identifier.
+     *
+     * @param mixed $identifier
+     *
+     * @return \Illuminate\Contracts\Auth\Authenticatable|null
+     */
+    public function retrieveById($identifier);
+
+    /**
+     * Retrieve a user by their unique identifier and "remember me" token.
+     *
+     * @param mixed  $identifier
+     * @param string $token
+     *
+     * @return \Illuminate\Contracts\Auth\Authenticatable|null
+     */
+    public function retrieveByToken($identifier, $token);
+
+    /**
+     * Update the "remember me" token for the given user in storage.
+     *
+     * @param Authenticatable $user
+     * @param string          $token
+     */
+    public function updateRememberToken(Authenticatable $user, $token);
+
+    /**
+     * Retrieve a user by the given credentials.
+     *
+     * @param array $credentials
+     *
+     * @return \Illuminate\Contracts\Auth\Authenticatable|null
+     */
+    public function retrieveByCredentials(array $credentials);
+
+    /**
+     * Validate a user against the given credentials.
+     *
+     * @param \Illuminate\Contracts\Auth\Authenticatable $user
+     * @param array                                      $credentials
+     *
+     * @return bool
+     */
+    public function validateCredentials(Authenticatable $model, array $credentials);
+
+    /**
+     * Set the fallback user provider.
+     *
+     * @param UserProvider $provider
+     */
+    public function setFallback(UserProvider $provider);
+
+    /**
+     * Create a new instance of the model.
+     *
+     * @return \Illuminate\Database\Eloquent\Model
+     */
+    public function createModel();
+
+    /**
+     * Perform all missing method calls on the underlying EloquentUserProvider fallback.
+     *
+     * @param string $name
+     * @param array  $arguments
+     *
+     * @return mixed
+     */
+    public function __call($name, $arguments);
+}


### PR DESCRIPTION
Make DatabaseUserProvider implementing an interface, so one can extend DatabaseUserProvider without messing with AdldapAuthServiceProvider. AdldapAuthServiceProvider now doesn't check for fixed class name, but for $provider implementing DatabaseUserProviderInterface. This is needed if one has to extend DatabaseUserProvider and therefor needs the dependencies in the Constructor