### PR TITLE
 Use Hash::make() instead of bcrypt()

### DIFF
--- a/docs/auth/setup.md
+++ b/docs/auth/setup.md
@@ -395,7 +395,7 @@ public function login(Request $request)
 
 ### Sync
 
-The password sync option allows you to automatically synchronize users LDAP passwords to your local database. These passwords are hashed natively by Laravel using the bcrypt() method.
+The password sync option allows you to automatically synchronize users LDAP passwords to your local database. These passwords are hashed natively by Laravel using the Hash::make() method.
 
 Enabling this option would also allow users to login to their accounts using the password last used when an LDAP connection was present.
 


### PR DESCRIPTION
Should fix #627 