### PR TITLE
Fixed removed fire method for event dispatcher

### DIFF
--- a/src/Auth/DatabaseUserProvider.php
+++ b/src/Auth/DatabaseUserProvider.php
@@ -104,7 +104,7 @@ class DatabaseUserProvider extends Provider
             // Set the currently authenticating LDAP user.
             $this->user = $user;
 
-            Event::fire(new DiscoveredWithCredentials($user));
+            Event::dispatch(new DiscoveredWithCredentials($user));
 
             // Import / locate the local user account.
             return Bus::dispatch(
@@ -126,7 +126,7 @@ class DatabaseUserProvider extends Provider
             // If an LDAP user was discovered, we can go
             // ahead and try to authenticate them.
             if (Resolver::authenticate($this->user, $credentials)) {
-                Event::fire(new AuthenticatedWithCredentials($this->user, $model));
+                Event::dispatch(new AuthenticatedWithCredentials($this->user, $model));
 
                 // Here we will perform authorization on the LDAP user. If all
                 // validation rules pass, we will allow the authentication
@@ -142,15 +142,15 @@ class DatabaseUserProvider extends Provider
                     if ($model->wasRecentlyCreated) {
                         // If the model was recently created, they
                         // have been imported successfully.
-                        Event::fire(new Imported($this->user, $model));
+                        Event::dispatch(new Imported($this->user, $model));
                     }
 
-                    Event::fire(new AuthenticationSuccessful($this->user, $model));
+                    Event::dispatch(new AuthenticationSuccessful($this->user, $model));
 
                     return true;
                 }
 
-                Event::fire(new AuthenticationRejected($this->user, $model));
+                Event::dispatch(new AuthenticationRejected($this->user, $model));
             }
 
             // LDAP Authentication failed.

--- a/src/Auth/DatabaseUserProvider.php
+++ b/src/Auth/DatabaseUserProvider.php
@@ -12,7 +12,6 @@ use Adldap\Laravel\Events\AuthenticationSuccessful;
 use Adldap\Laravel\Events\DiscoveredWithCredentials;
 use Adldap\Laravel\Events\AuthenticatedWithCredentials;
 use Illuminate\Support\Facades\Bus;
-use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Auth\EloquentUserProvider;
 use Illuminate\Contracts\Hashing\Hasher;
@@ -104,7 +103,7 @@ class DatabaseUserProvider extends Provider
             // Set the currently authenticating LDAP user.
             $this->user = $user;
 
-            Event::dispatch(new DiscoveredWithCredentials($user));
+            event(new DiscoveredWithCredentials($user));
 
             // Import / locate the local user account.
             return Bus::dispatch(
@@ -126,7 +125,7 @@ class DatabaseUserProvider extends Provider
             // If an LDAP user was discovered, we can go
             // ahead and try to authenticate them.
             if (Resolver::authenticate($this->user, $credentials)) {
-                Event::dispatch(new AuthenticatedWithCredentials($this->user, $model));
+                event(new AuthenticatedWithCredentials($this->user, $model));
 
                 // Here we will perform authorization on the LDAP user. If all
                 // validation rules pass, we will allow the authentication
@@ -142,15 +141,15 @@ class DatabaseUserProvider extends Provider
                     if ($model->wasRecentlyCreated) {
                         // If the model was recently created, they
                         // have been imported successfully.
-                        Event::dispatch(new Imported($this->user, $model));
+                        event(new Imported($this->user, $model));
                     }
 
-                    Event::dispatch(new AuthenticationSuccessful($this->user, $model));
+                    event(new AuthenticationSuccessful($this->user, $model));
 
                     return true;
                 }
 
-                Event::dispatch(new AuthenticationRejected($this->user, $model));
+                event(new AuthenticationRejected($this->user, $model));
             }
 
             // LDAP Authentication failed.

--- a/src/Auth/NoDatabaseUserProvider.php
+++ b/src/Auth/NoDatabaseUserProvider.php
@@ -46,7 +46,7 @@ class NoDatabaseUserProvider extends Provider
     public function retrieveByCredentials(array $credentials)
     {
         if ($user = Resolver::byCredentials($credentials)) {
-            Event::fire(new DiscoveredWithCredentials($user));
+            Event::dispatch(new DiscoveredWithCredentials($user));
 
             return $user;
         }
@@ -58,15 +58,15 @@ class NoDatabaseUserProvider extends Provider
     public function validateCredentials(Authenticatable $user, array $credentials)
     {
         if (Resolver::authenticate($user, $credentials)) {
-            Event::fire(new AuthenticatedWithCredentials($user));
+            Event::dispatch(new AuthenticatedWithCredentials($user));
 
             if ($this->passesValidation($user)) {
-                Event::fire(new AuthenticationSuccessful($user));
+                Event::dispatch(new AuthenticationSuccessful($user));
 
                 return true;
             }
 
-            Event::fire(new AuthenticationRejected($user));
+            Event::dispatch(new AuthenticationRejected($user));
         }
 
         return false;

--- a/src/Auth/NoDatabaseUserProvider.php
+++ b/src/Auth/NoDatabaseUserProvider.php
@@ -7,7 +7,6 @@ use Adldap\Laravel\Events\AuthenticationRejected;
 use Adldap\Laravel\Events\AuthenticationSuccessful;
 use Adldap\Laravel\Events\DiscoveredWithCredentials;
 use Adldap\Laravel\Events\AuthenticatedWithCredentials;
-use Illuminate\Support\Facades\Event;
 use Illuminate\Contracts\Auth\Authenticatable;
 
 class NoDatabaseUserProvider extends Provider
@@ -46,7 +45,7 @@ class NoDatabaseUserProvider extends Provider
     public function retrieveByCredentials(array $credentials)
     {
         if ($user = Resolver::byCredentials($credentials)) {
-            Event::dispatch(new DiscoveredWithCredentials($user));
+            event(new DiscoveredWithCredentials($user));
 
             return $user;
         }
@@ -58,15 +57,15 @@ class NoDatabaseUserProvider extends Provider
     public function validateCredentials(Authenticatable $user, array $credentials)
     {
         if (Resolver::authenticate($user, $credentials)) {
-            Event::dispatch(new AuthenticatedWithCredentials($user));
+            event(new AuthenticatedWithCredentials($user));
 
             if ($this->passesValidation($user)) {
-                Event::dispatch(new AuthenticationSuccessful($user));
+                event(new AuthenticationSuccessful($user));
 
                 return true;
             }
 
-            Event::dispatch(new AuthenticationRejected($user));
+            event(new AuthenticationRejected($user));
         }
 
         return false;

--- a/src/Commands/Console/Import.php
+++ b/src/Commands/Console/Import.php
@@ -12,7 +12,6 @@ use Adldap\Laravel\Commands\SyncPassword;
 use Adldap\Laravel\Commands\Import as ImportUser;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\Bus;
-use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Database\Eloquent\Model;
 
@@ -234,7 +233,7 @@ class Import extends Command
         if ($model->save() && $model->wasRecentlyCreated) {
             $imported = true;
 
-            Event::dispatch(new Imported($user, $model));
+            event(new Imported($user, $model));
 
             // Log the successful import.
             if ($this->isLogging()) {

--- a/src/Commands/Console/Import.php
+++ b/src/Commands/Console/Import.php
@@ -234,7 +234,7 @@ class Import extends Command
         if ($model->save() && $model->wasRecentlyCreated) {
             $imported = true;
 
-            Event::fire(new Imported($user, $model));
+            Event::dispatch(new Imported($user, $model));
 
             // Log the successful import.
             if ($this->isLogging()) {

--- a/src/Commands/Import.php
+++ b/src/Commands/Import.php
@@ -7,7 +7,6 @@ use Adldap\Laravel\Facades\Resolver;
 use Adldap\Laravel\Events\Importing;
 use Adldap\Laravel\Events\Synchronized;
 use Adldap\Laravel\Events\Synchronizing;
-use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Database\Eloquent\Model;
 
@@ -52,14 +51,14 @@ class Import
         $model = $this->findUser() ?: $this->model->newInstance();
 
         if (! $model->exists) {
-            Event::dispatch(new Importing($this->user, $model));
+            event(new Importing($this->user, $model));
         }
 
-        Event::dispatch(new Synchronizing($this->user, $model));
+        event(new Synchronizing($this->user, $model));
 
         $this->sync($model);
 
-        Event::dispatch(new Synchronized($this->user, $model));
+        event(new Synchronized($this->user, $model));
 
         return $model;
     }

--- a/src/Commands/Import.php
+++ b/src/Commands/Import.php
@@ -52,14 +52,14 @@ class Import
         $model = $this->findUser() ?: $this->model->newInstance();
 
         if (! $model->exists) {
-            Event::fire(new Importing($this->user, $model));
+            Event::dispatch(new Importing($this->user, $model));
         }
 
-        Event::fire(new Synchronizing($this->user, $model));
+        Event::dispatch(new Synchronizing($this->user, $model));
 
         $this->sync($model);
 
-        Event::fire(new Synchronized($this->user, $model));
+        Event::dispatch(new Synchronized($this->user, $model));
 
         return $model;
     }

--- a/src/Middleware/WindowsAuthenticate.php
+++ b/src/Middleware/WindowsAuthenticate.php
@@ -105,12 +105,12 @@ class WindowsAuthenticate
      *
      * @param User       $user
      * @param mixed|null $model
-     * 
+     *
      * @return void
      */
     protected function fireAuthenticatedEvent(User $user, $model = null)
     {
-        Event::fire(new AuthenticatedWithWindows($user, $model));
+        Event::dispatch(new AuthenticatedWithWindows($user, $model));
     }
 
     /**

--- a/src/Middleware/WindowsAuthenticate.php
+++ b/src/Middleware/WindowsAuthenticate.php
@@ -13,7 +13,6 @@ use Adldap\Laravel\Events\AuthenticatedWithWindows;
 use Illuminate\Http\Request;
 use Illuminate\Contracts\Auth\Guard;
 use Illuminate\Support\Facades\Bus;
-use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Config;
 
 class WindowsAuthenticate
@@ -110,7 +109,7 @@ class WindowsAuthenticate
      */
     protected function fireAuthenticatedEvent(User $user, $model = null)
     {
-        Event::dispatch(new AuthenticatedWithWindows($user, $model));
+        event(new AuthenticatedWithWindows($user, $model));
     }
 
     /**

--- a/src/Resolvers/UserResolver.php
+++ b/src/Resolvers/UserResolver.php
@@ -12,7 +12,6 @@ use Adldap\Laravel\Events\Authenticating;
 use Adldap\Laravel\Events\AuthenticationFailed;
 use Adldap\Laravel\Auth\NoDatabaseUserProvider;
 use Illuminate\Support\Facades\Auth;
-use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Contracts\Auth\UserProvider;
 use Illuminate\Contracts\Auth\Authenticatable;
@@ -113,15 +112,15 @@ class UserResolver implements ResolverInterface
 
         $password = $this->getPasswordFromCredentials($credentials);
 
-        Event::dispatch(new Authenticating($user, $username));
+        event(new Authenticating($user, $username));
 
         if ($this->getLdapAuthProvider()->auth()->attempt($username, $password)) {
-            Event::dispatch(new Authenticated($user));
+            event(new Authenticated($user));
 
             return true;
         }
 
-        Event::dispatch(new AuthenticationFailed($user));
+        event(new AuthenticationFailed($user));
 
         return false;
     }

--- a/src/Resolvers/UserResolver.php
+++ b/src/Resolvers/UserResolver.php
@@ -113,15 +113,15 @@ class UserResolver implements ResolverInterface
 
         $password = $this->getPasswordFromCredentials($credentials);
 
-        Event::fire(new Authenticating($user, $username));
+        Event::dispatch(new Authenticating($user, $username));
 
         if ($this->getLdapAuthProvider()->auth()->attempt($username, $password)) {
-            Event::fire(new Authenticated($user));
+            Event::dispatch(new Authenticated($user));
 
             return true;
         }
 
-        Event::fire(new AuthenticationFailed($user));
+        Event::dispatch(new AuthenticationFailed($user));
 
         return false;
     }

--- a/src/Validation/Rules/DenyTrashed.php
+++ b/src/Validation/Rules/DenyTrashed.php
@@ -13,7 +13,7 @@ class DenyTrashed extends Rule
     public function isValid()
     {
         if ($this->isTrashed()) {
-            Event::fire(
+            Event::dispatch(
                 new AuthenticatedModelTrashed($this->user, $this->model)
             );
 

--- a/src/Validation/Rules/DenyTrashed.php
+++ b/src/Validation/Rules/DenyTrashed.php
@@ -2,7 +2,6 @@
 
 namespace Adldap\Laravel\Validation\Rules;
 
-use Illuminate\Support\Facades\Event;
 use Adldap\Laravel\Events\AuthenticatedModelTrashed;
 
 class DenyTrashed extends Rule
@@ -13,7 +12,7 @@ class DenyTrashed extends Rule
     public function isValid()
     {
         if ($this->isTrashed()) {
-            Event::dispatch(
+            event(
                 new AuthenticatedModelTrashed($this->user, $this->model)
             );
 

--- a/tests/DatabaseTestCase.php
+++ b/tests/DatabaseTestCase.php
@@ -11,7 +11,7 @@ use Illuminate\Support\Facades\Schema;
 
 class DatabaseTestCase extends TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 


### PR DESCRIPTION
As of Laravel 5.8, the `Event::fire` method has been officially removed and replaced with `Event::dispatch`.

https://laravel.com/docs/5.8/upgrade#events

This PR adds support for Laravel 5.8, however will mean the minimum supported version will now be 5.4+

If keeping 5.0-5.3 support is imperative, it may be possible to create a function to delegate between `Event::fire` and `Event::dispatch` based upon the value returned from `App::version()`.
