### PR TITLE
Fix tests for orchestra/testbench v3.8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     },
     "require-dev": {
         "mockery/mockery": "~1.0",
-        "phpunit/phpunit": "~8.0",
+        "phpunit/phpunit": "~7.0",
         "orchestra/testbench": "~3.8"
     },
     "archive": {

--- a/composer.json
+++ b/composer.json
@@ -10,8 +10,8 @@
     },
     "require-dev": {
         "mockery/mockery": "~1.0",
-        "phpunit/phpunit": "~7.0",
-        "orchestra/testbench": "~3.7"
+        "phpunit/phpunit": "~8.0",
+        "orchestra/testbench": "~3.8"
     },
     "archive": {
         "exclude": ["/tests"]

--- a/tests/DatabaseTestCase.php
+++ b/tests/DatabaseTestCase.php
@@ -11,7 +11,7 @@ use Illuminate\Support\Facades\Schema;
 
 class DatabaseTestCase extends TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 


### PR DESCRIPTION
The latest version of `orchestra/testbench` adds a `void` return type for PHPUnit 8 compatibility.

This PR amends the method signature of `setUp` for `DatabaseTestCase` to also add compatibility with its parent class and fixes the currently failing tests.