### PR TITLE
BindsLdapUserModel - Laravel 5.8

### DIFF
--- a/src/Auth/DatabaseUserProvider.php
+++ b/src/Auth/DatabaseUserProvider.php
@@ -12,7 +12,6 @@ use Adldap\Laravel\Events\AuthenticationSuccessful;
 use Adldap\Laravel\Events\DiscoveredWithCredentials;
 use Adldap\Laravel\Events\AuthenticatedWithCredentials;
 use Illuminate\Support\Facades\Bus;
-use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Auth\EloquentUserProvider;
 use Illuminate\Contracts\Hashing\Hasher;
@@ -104,7 +103,7 @@ class DatabaseUserProvider extends Provider
             // Set the currently authenticating LDAP user.
             $this->user = $user;
 
-            Event::fire(new DiscoveredWithCredentials($user));
+            event(new DiscoveredWithCredentials($user));
 
             // Import / locate the local user account.
             return Bus::dispatch(
@@ -126,7 +125,7 @@ class DatabaseUserProvider extends Provider
             // If an LDAP user was discovered, we can go
             // ahead and try to authenticate them.
             if (Resolver::authenticate($this->user, $credentials)) {
-                Event::fire(new AuthenticatedWithCredentials($this->user, $model));
+                event(new AuthenticatedWithCredentials($this->user, $model));
 
                 // Here we will perform authorization on the LDAP user. If all
                 // validation rules pass, we will allow the authentication
@@ -142,15 +141,15 @@ class DatabaseUserProvider extends Provider
                     if ($model->wasRecentlyCreated) {
                         // If the model was recently created, they
                         // have been imported successfully.
-                        Event::fire(new Imported($this->user, $model));
+                        event(new Imported($this->user, $model));
                     }
 
-                    Event::fire(new AuthenticationSuccessful($this->user, $model));
+                    event(new AuthenticationSuccessful($this->user, $model));
 
                     return true;
                 }
 
-                Event::fire(new AuthenticationRejected($this->user, $model));
+                event(new AuthenticationRejected($this->user, $model));
             }
 
             // LDAP Authentication failed.

--- a/src/Auth/NoDatabaseUserProvider.php
+++ b/src/Auth/NoDatabaseUserProvider.php
@@ -7,7 +7,6 @@ use Adldap\Laravel\Events\AuthenticationRejected;
 use Adldap\Laravel\Events\AuthenticationSuccessful;
 use Adldap\Laravel\Events\DiscoveredWithCredentials;
 use Adldap\Laravel\Events\AuthenticatedWithCredentials;
-use Illuminate\Support\Facades\Event;
 use Illuminate\Contracts\Auth\Authenticatable;
 
 class NoDatabaseUserProvider extends Provider
@@ -46,7 +45,7 @@ class NoDatabaseUserProvider extends Provider
     public function retrieveByCredentials(array $credentials)
     {
         if ($user = Resolver::byCredentials($credentials)) {
-            Event::fire(new DiscoveredWithCredentials($user));
+            event(new DiscoveredWithCredentials($user));
 
             return $user;
         }
@@ -58,15 +57,15 @@ class NoDatabaseUserProvider extends Provider
     public function validateCredentials(Authenticatable $user, array $credentials)
     {
         if (Resolver::authenticate($user, $credentials)) {
-            Event::fire(new AuthenticatedWithCredentials($user));
+            event(new AuthenticatedWithCredentials($user));
 
             if ($this->passesValidation($user)) {
-                Event::fire(new AuthenticationSuccessful($user));
+                event(new AuthenticationSuccessful($user));
 
                 return true;
             }
 
-            Event::fire(new AuthenticationRejected($user));
+            event(new AuthenticationRejected($user));
         }
 
         return false;

--- a/src/Commands/Console/Import.php
+++ b/src/Commands/Console/Import.php
@@ -11,7 +11,6 @@ use Adldap\Laravel\Commands\SyncPassword;
 use Adldap\Laravel\Commands\Import as ImportUser;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\Bus;
-use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Database\Eloquent\Model;
 
@@ -254,7 +253,7 @@ class Import extends Command
         if ($model->save() && $model->wasRecentlyCreated) {
             $imported = true;
 
-            Event::fire(new Imported($user, $model));
+            event(new Imported($user, $model));
 
             // Log the successful import.
             if ($this->isLogging()) {

--- a/src/Commands/Import.php
+++ b/src/Commands/Import.php
@@ -7,7 +7,6 @@ use Adldap\Laravel\Events\Importing;
 use Adldap\Laravel\Events\Synchronized;
 use Adldap\Laravel\Events\Synchronizing;
 use Illuminate\Support\Str;
-use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Database\Eloquent\Model;
 
@@ -61,14 +60,14 @@ class Import
         $model = $this->findByCredentials() ?: $this->model->newInstance();
 
         if (! $model->exists) {
-            Event::fire(new Importing($this->user, $model));
+            event(new Importing($this->user, $model));
         }
 
-        Event::fire(new Synchronizing($this->user, $model));
+        event(new Synchronizing($this->user, $model));
 
         $this->sync($model);
 
-        Event::fire(new Synchronized($this->user, $model));
+        event(new Synchronized($this->user, $model));
 
         return $model;
     }

--- a/src/Middleware/WindowsAuthenticate.php
+++ b/src/Middleware/WindowsAuthenticate.php
@@ -13,7 +13,6 @@ use Adldap\Laravel\Events\AuthenticatedWithWindows;
 use Illuminate\Http\Request;
 use Illuminate\Contracts\Auth\Guard;
 use Illuminate\Support\Facades\Bus;
-use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Config;
 
 class WindowsAuthenticate
@@ -112,7 +111,7 @@ class WindowsAuthenticate
      */
     protected function fireAuthenticatedEvent(User $user, $model = null)
     {
-        Event::fire(new AuthenticatedWithWindows($user, $model));
+        event(new AuthenticatedWithWindows($user, $model));
     }
 
     /**

--- a/src/Resolvers/UserResolver.php
+++ b/src/Resolvers/UserResolver.php
@@ -11,7 +11,6 @@ use Adldap\Laravel\Events\Authenticating;
 use Adldap\Laravel\Events\AuthenticationFailed;
 use Adldap\Laravel\Auth\NoDatabaseUserProvider;
 use Illuminate\Support\Facades\Auth;
-use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Contracts\Auth\UserProvider;
 use Illuminate\Contracts\Auth\Authenticatable;
@@ -111,15 +110,15 @@ class UserResolver implements ResolverInterface
 
         $password = $this->getPasswordFromCredentials($credentials);
 
-        Event::fire(new Authenticating($user, $username));
+        event(new Authenticating($user, $username));
 
         if ($this->getLdapAuthProvider()->auth()->attempt($username, $password)) {
-            Event::fire(new Authenticated($user));
+            event(new Authenticated($user));
 
             return true;
         }
 
-        Event::fire(new AuthenticationFailed($user));
+        event(new AuthenticationFailed($user));
 
         return false;
     }

--- a/src/Validation/Rules/DenyTrashed.php
+++ b/src/Validation/Rules/DenyTrashed.php
@@ -2,7 +2,6 @@
 
 namespace Adldap\Laravel\Validation\Rules;
 
-use Illuminate\Support\Facades\Event;
 use Adldap\Laravel\Events\AuthenticatedModelTrashed;
 
 class DenyTrashed extends Rule
@@ -13,7 +12,7 @@ class DenyTrashed extends Rule
     public function isValid()
     {
         if ($this->isTrashed()) {
-            Event::fire(
+            event(
                 new AuthenticatedModelTrashed($this->user, $this->model)
             );
 

--- a/tests/DatabaseTestCase.php
+++ b/tests/DatabaseTestCase.php
@@ -11,7 +11,7 @@ use Illuminate\Support\Facades\Schema;
 
 class DatabaseTestCase extends TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 


### PR DESCRIPTION
### **File Being Edited =>** Adldap\Laravel\Listeners\BindsLdapUserModel

> In Laravel 5.8 i have had to change from 

```
public function handle($event)
    {
        if (
            $this->isUsingAdldapProvider($event->guard)
            && $this->canBind($event->user)
            && $user = Resolver::byModel($event->user)
        ) {
            $event->user->setLdapUser($user);
        }
    }

    protected function isUsingAdldapProvider($guard) : bool
    {
        return Auth::guard($guard)->getProvider() instanceof DatabaseUserProvider;
    }
```

### **to**

```
public function handle($event)
    {
        if (
            $this->isUsingAdldapProvider()
            && $this->canBind($event->user)
            && $user = Resolver::byModel($event->user)
        ) {
            $event->user->setLdapUser($user);
        }
    }

    protected function isUsingAdldapProvider() : bool
    {
        return Auth::guard()->getProvider() instanceof DatabaseUserProvider;
    }
```

Unique way that works