### PR TITLE
Allow User Resolver class to be configured

### DIFF
--- a/src/AdldapAuthServiceProvider.php
+++ b/src/AdldapAuthServiceProvider.php
@@ -51,7 +51,8 @@ class AdldapAuthServiceProvider extends ServiceProvider
     {
         // Bind the user resolver instance into the IoC.
         $this->app->bind(ResolverInterface::class, function () {
-            return new UserResolver(
+            $resolverClass = Config::get('ldap_auth.resolver', UserResolver::class);
+            return new $resolverClass(
                 $this->app->make(AdldapInterface::class)
             );
         });

--- a/src/Config/auth.php
+++ b/src/Config/auth.php
@@ -37,6 +37,18 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Resolver
+    |--------------------------------------------------------------------------
+    |
+    | The User Resolver class can be configured in case additional processing is
+    | needed before received LDAP user data is passed on to the User Provider.
+    |
+    */
+
+    'resolver' => Adldap\Laravel\Resolvers\UserResolver::class,
+
+    /*
+    |--------------------------------------------------------------------------
     | Model
     |--------------------------------------------------------------------------
     |

--- a/tests/Models/TestUserResolver.php
+++ b/tests/Models/TestUserResolver.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Adldap\Laravel\Tests\Models;
+
+class TestUserResolver
+{
+}

--- a/tests/UserResolverTest.php
+++ b/tests/UserResolverTest.php
@@ -2,6 +2,8 @@
 
 namespace Adldap\Laravel\Tests;
 
+use Adldap\Laravel\Resolvers\ResolverInterface;
+use Adldap\Laravel\Tests\Models\TestUserResolver;
 use Mockery as m;
 use Adldap\Query\Builder;
 use Adldap\AdldapInterface;
@@ -18,6 +20,23 @@ use Illuminate\Foundation\Testing\WithFaker;
 class UserResolverTest extends TestCase
 {
     use WithFaker;
+
+    /** @test */
+    public function resolver_class_is_configurable()
+    {
+        // default
+        $instance = $this->app->make(ResolverInterface::class);
+
+        $this->assertTrue($instance instanceof UserResolver);
+
+        // configured
+        $this->refreshApplication();
+        Config::set('ldap_auth.resolver', TestUserResolver::class);
+
+        $instance = $this->app->make(ResolverInterface::class);
+
+        $this->assertTrue($instance instanceof TestUserResolver);
+    }
 
     /** @test */
     public function eloquent_username_default()


### PR DESCRIPTION
My use case:
I need to filter which users can use the app based on their assigned groups.
As users are imported into database before authentication (`DatabaseUserProvider::retrieveByCredentials`) the database gets cluttered.
With my own configured resolver I can check wether user can at all access the app and pass it on to authentication or not.