### PR TITLE
Return console output instead of exception

### DIFF
--- a/src/Commands/Console/Import.php
+++ b/src/Commands/Console/Import.php
@@ -3,7 +3,6 @@
 namespace Adldap\Laravel\Commands\Console;
 
 use Exception;
-use RuntimeException;
 use Adldap\Models\User;
 use Illuminate\Support\Arr;
 use UnexpectedValueException;
@@ -48,7 +47,6 @@ class Import extends Command
     /**
      * Execute the console command.
      *
-     * @throws RuntimeException
      * @throws \Adldap\Models\ModelNotFoundException
      *
      * @return void

--- a/src/Commands/Console/Import.php
+++ b/src/Commands/Console/Import.php
@@ -60,7 +60,8 @@ class Import extends Command
         $count = count($users);
 
         if ($count === 0) {
-            throw new RuntimeException('There were no users found to import.');
+            $this->info('There were no users found to import.');
+            exit;
         } elseif ($count === 1) {
             $this->info("Found user '{$users[0]->getCommonName()}'.");
         } else {

--- a/src/Commands/Console/Import.php
+++ b/src/Commands/Console/Import.php
@@ -58,8 +58,7 @@ class Import extends Command
         $count = count($users);
 
         if ($count === 0) {
-            $this->info('There were no users found to import.');
-            exit;
+            return $this->info('There were no users found to import.');
         } elseif ($count === 1) {
             $this->info("Found user '{$users[0]->getCommonName()}'.");
         } else {


### PR DESCRIPTION
The command is currently throwing an exception, if no user were found.

Since this exception is never and can't be catched, the function should rather return an information text instead of throwing this exception.