### PR TITLE
Start the process to support Laravel 7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,14 +5,14 @@
     "license": "MIT",
     "type": "project",
     "require": {
-        "php": ">=7.1",
-        "adldap2/adldap2": "^10.1",
-        "illuminate/support": "~5.5|~6.0"
+        "php": ">=7.2",
+        "adldap2/adldap2": "dev-master",
+        "illuminate/support": "~7.0"
     },
     "require-dev": {
         "mockery/mockery": "~1.0",
-        "phpunit/phpunit": "~7.0",
-        "orchestra/testbench": "~3.7"
+        "phpunit/phpunit": "~8.5",
+        "orchestra/testbench": "~5.0"
     },
     "archive": {
         "exclude": ["/tests"]

--- a/tests/DatabaseImporterTest.php
+++ b/tests/DatabaseImporterTest.php
@@ -44,12 +44,11 @@ class DatabaseImporterTest extends DatabaseTestCase
         $this->assertTrue($m1->is($m2));
     }
 
-    /**
-     * @test
-     * @expectedException \UnexpectedValueException
-     */
+    /** @test */
     public function exception_is_thrown_when_guid_is_null()
     {
+        $this->expectException(\UnexpectedValueException::class);
+
         $u = $this->makeLdapUser([
             'objectguid' => null,
         ]);
@@ -57,12 +56,11 @@ class DatabaseImporterTest extends DatabaseTestCase
         (new Import($u, new TestUser()))->handle();
     }
 
-    /**
-     * @test
-     * @expectedException \UnexpectedValueException
-     */
+    /** @test */
     public function exception_is_thrown_when_guid_is_empty()
     {
+        $this->expectException(\UnexpectedValueException::class);
+
         $u = $this->makeLdapUser([
             'objectguid' => ' ',
         ]);
@@ -70,12 +68,11 @@ class DatabaseImporterTest extends DatabaseTestCase
         (new Import($u, new TestUser()))->handle();
     }
 
-    /**
-     * @test
-     * @expectedException \UnexpectedValueException
-     */
+    /** @test */
     public function exception_is_thrown_when_username_is_null()
     {
+        $this->expectException(\UnexpectedValueException::class);
+
         $u = $this->makeLdapUser([
             'userprincipalname' => null,
         ]);
@@ -83,12 +80,11 @@ class DatabaseImporterTest extends DatabaseTestCase
         (new Import($u, new TestUser()))->handle();
     }
 
-    /**
-     * @test
-     * @expectedException \UnexpectedValueException
-     */
+    /** @test */
     public function exception_is_thrown_when_username_is_empty()
     {
+        $this->expectException(\UnexpectedValueException::class);
+
         $u = $this->makeLdapUser([
             'userprincipalname' => ' ',
         ]);

--- a/tests/DatabaseProviderTest.php
+++ b/tests/DatabaseProviderTest.php
@@ -18,12 +18,11 @@ class DatabaseProviderTest extends DatabaseTestCase
 {
     use WithFaker;
 
-    /**
-     * @test
-     * @expectedException \RuntimeException
-     */
+    /** @test */
     public function configuration_not_found_exception_when_config_is_null()
     {
+        $this->expectException(\RuntimeException::class);
+
         config(['ldap' => null]);
 
         App::make(AdldapInterface::class);


### PR DESCRIPTION
All the tests except for `DatabaseProviderTest::auth_attempts_fallback_using_config_option` work and I've resolved the warnings around `@expectedException` annotations. I can't quite tell what's going on. I _think_ it's because AdLdap2 is throwing exceptions when before it only returned null or something? I wouldn't mind taking it on, but could use some direction on how you want to handle it.

This would close #852 and _probably_ mean a new version? Again, some direction would be helpful if you want some help on it. I've set the `adldap2/adldap2` dependency to be `dev-master` because I saw you did some work on supporting 7 today.

Let me know!