### PR TITLE
Lazy connection before searching for user while trying to authenticate

### DIFF
--- a/src/Resolvers/UserResolver.php
+++ b/src/Resolvers/UserResolver.php
@@ -203,7 +203,7 @@ class UserResolver implements ResolverInterface
     {
         $provider = $this->ldap->getProvider($this->connection ?? $this->getLdapAuthConnectionName());
 
-        if (!$provider->getConnection()->isBound()) {
+        if (! $provider->getConnection()->isBound()) {
             // We'll make sure we have a bound connection before
             // allowing dynamic calls on the default provider.
             $provider->connect();

--- a/src/Resolvers/UserResolver.php
+++ b/src/Resolvers/UserResolver.php
@@ -201,7 +201,15 @@ class UserResolver implements ResolverInterface
      */
     protected function getLdapAuthProvider(): ProviderInterface
     {
-        return $this->ldap->getProvider($this->connection ?? $this->getLdapAuthConnectionName());
+        $provider = $this->ldap->getProvider($this->connection ?? $this->getLdapAuthConnectionName());
+
+        if (!$provider->getConnection()->isBound()) {
+            // We'll make sure we have a bound connection before
+            // allowing dynamic calls on the default provider.
+            $provider->connect();
+        }
+
+        return $provider;
     }
 
     /**

--- a/tests/DatabaseProviderTest.php
+++ b/tests/DatabaseProviderTest.php
@@ -8,8 +8,6 @@ use Adldap\Connections\Provider;
 use Adldap\Connections\ProviderInterface;
 use Adldap\Laravel\Commands\Import;
 use Adldap\Laravel\Facades\Resolver;
-use Adldap\Laravel\Resolvers\ResolverInterface;
-use Adldap\Laravel\Resolvers\UserResolver;
 use Adldap\Laravel\Tests\Handlers\LdapAttributeHandler;
 use Adldap\Laravel\Tests\Models\TestUser as EloquentUser;
 use Adldap\Laravel\Tests\Scopes\JohnDoeScope;

--- a/tests/UserResolverTest.php
+++ b/tests/UserResolverTest.php
@@ -3,6 +3,7 @@
 namespace Adldap\Laravel\Tests;
 
 use Adldap\AdldapInterface;
+use Adldap\Connections\ConnectionInterface;
 use Adldap\Connections\ProviderInterface;
 use Adldap\Laravel\Auth\NoDatabaseUserProvider;
 use Adldap\Laravel\Resolvers\UserResolver;
@@ -85,6 +86,11 @@ class UserResolverTest extends TestCase
             ->shouldReceive('users')->once()->andReturn($builder);
 
         $ad = m::mock(AdldapInterface::class);
+        $ldapConnection = m::mock(ConnectionInterface::class);
+        $ldapConnection->shouldReceive('isBound')->once()->andReturn(false);
+
+        $provider->shouldReceive('getConnection')->once()->andReturn($ldapConnection);
+        $provider->shouldReceive('connect')->once();
 
         $ad->shouldReceive('getProvider')->with('default')->andReturn($provider);
 
@@ -99,8 +105,14 @@ class UserResolverTest extends TestCase
         Config::shouldReceive('get')->once()->with('ldap_auth.connection', 'default')->andReturn('other-domain');
 
         $ad = m::mock(AdldapInterface::class);
+        $provider = m::mock(ProviderInterface::class);
 
-        $ad->shouldReceive('getProvider')->andReturn(m::mock(ProviderInterface::class))->with('other-domain');
+        $ad->shouldReceive('getProvider')->with('other-domain')->andReturn($provider);
+        $ldapConnection = m::mock(ConnectionInterface::class);
+        $ldapConnection->shouldReceive('isBound')->once()->andReturn(false);
+
+        $provider->shouldReceive('getConnection')->once()->andReturn($ldapConnection);
+        $provider->shouldReceive('connect')->once();
 
         $r = m::mock(UserResolver::class, [$ad])->makePartial();
 
@@ -130,6 +142,11 @@ class UserResolverTest extends TestCase
             ->shouldReceive('users')->once()->andReturn($query);
 
         $ad = m::mock(AdldapInterface::class);
+        $ldapConnection = m::mock(ConnectionInterface::class);
+        $ldapConnection->shouldReceive('isBound')->once()->andReturn(false);
+
+        $ldapProvider->shouldReceive('getConnection')->once()->andReturn($ldapConnection);
+        $ldapProvider->shouldReceive('connect')->once();
 
         $ad->shouldReceive('getProvider')->once()->andReturn($ldapProvider);
 


### PR DESCRIPTION
- Laravel Version: 7.1.3
- Adldap2-Laravel Version: v6.0.9
- PHP Version: 7.4.3
- LDAP Type: OpenLDAP

### Description:
When trying to authenticate users using the `NoDatabaseUserProvider` the package is not binding to the LDAP server but only trying to search for the specific record:
```
[2020-03-14 15:47:42] local.INFO: LDAP (ldap://openldap:389) - Connection: default - Operation: Search - Base DN: dc=domain,dc=com - Filter: (&(objectclass=inetorgperson)(objectclass=person)(uid=testuser)) - Selected: (*,entryuuid) - Time Elapsed: 0.55
```
However if I use the facade or inject the `AdldapInterface` the package seems to work just fine. The difference that I noticed is that the facade and the injected interface, when calling the `search()` method using the magic `__call` method on the `Adldap` instance, is trying to connect if the connection is not bound:
```
    /**
     * {@inheritdoc}
     */
    public function __call($method, $parameters)
    {
        $provider = $this->getDefaultProvider();

        if (!$provider->getConnection()->isBound()) {
            // We'll make sure we have a bound connection before
            // allowing dynamic calls on the default provider.
            $provider->connect();
        }

        return call_user_func_array([$provider, $method], $parameters);
    }
```
So right now if I try to search for a user, I see also on the log that the connection is bound before searching:
```
[2020-03-14 17:52:18] local.INFO: LDAP (ldap://openldap:389) - Connection: default - Operation: Binding - Username: cn=admin,dc=domain,dc=com  
[2020-03-14 17:52:18] local.INFO: LDAP (ldap://openldap:389) - Connection: default - Operation: Bound - Username: cn=admin,dc=domain,dc=com  
[2020-03-14 17:52:18] local.INFO: LDAP (ldap://openldap:389) - Connection: default - Operation: Search - Base DN: dc=domain,dc=com - Filter: (&(objectclass=inetorgperson)(objectclass=person)(uid=testuser)) - Selected: (*) - Time Elapsed: 0.32
```
But this is not the case with the `UserResolver` `query` method. Basically is just calling to get the provider, and executing the call without trying to establish the connection to the LDAP before checking if the user exists on the LDAP server, and then to authenticate with it. So after I did the change from the PR, I got in log:
```
[2020-03-14 15:49:09] local.INFO: LDAP (ldap://openldap:389) - Connection: default - Operation: Binding - Username: cn=admin,dc=domain,dc=com  
[2020-03-14 15:49:09] local.INFO: LDAP (ldap://openldap:389) - Connection: default - Operation: Bound - Username: cn=admin,dc=domain,dc=com  
[2020-03-14 15:49:09] local.INFO: LDAP (ldap://openldap:389) - Connection: default - Operation: Search - Base DN: dc=domain,dc=com - Filter: (&(objectclass=inetorgperson)(objectclass=person)(uid=testuser)) - Selected: (*,entryuuid) - Time Elapsed: 0.28  
[2020-03-14 15:49:09] local.INFO: User 'Test User has been successfully found for authentication.  
[2020-03-14 15:49:09] local.INFO: User 'Test User'' is authenticating with username: 'uid=testuser,ou=People,dc=domain,dc=com'  
[2020-03-14 15:49:09] local.INFO: LDAP (ldap://openldap:389) - Connection: default - Operation: Attempting - Username: uid=testuser,ou=People,dc=domain,dc=com  
[2020-03-14 15:49:09] local.INFO: LDAP (ldap://openldap:389) - Connection: default - Operation: Binding - Username: uid=testuser,ou=People,dc=domain,dc=com  
[2020-03-14 15:49:09] local.INFO: LDAP (ldap://openldap:389) - Connection: default - Operation: Bound - Username: uid=testuser,ou=People,dc=domain,dc=com  
[2020-03-14 15:49:09] local.INFO: LDAP (ldap://openldap:389) - Connection: default - Operation: Passed - Username: uid=testuser,ou=People,dc=domain,dc=com  
[2020-03-14 15:49:09] local.INFO: LDAP (ldap://openldap:389) - Connection: default - Operation: Binding - Username: cn=admin,dc=domain,dc=com  
[2020-03-14 15:49:09] local.INFO: LDAP (ldap://openldap:389) - Connection: default - Operation: Bound - Username: cn=admin,dc=domain,dc=com  
[2020-03-14 15:49:09] local.INFO: User 'Test User' has successfully passed LDAP authentication.  
[2020-03-14 15:49:09] local.INFO: User 'Test User' has been successfully logged in.  
[2020-03-14 15:49:09] local.INFO: LDAP (ldap://openldap:389) - Connection: default - Operation: Binding - Username: cn=admin,dc=domain,dc=com  
[2020-03-14 15:49:09] local.INFO: LDAP (ldap://openldap:389) - Connection: default - Operation: Bound - Username: cn=admin,dc=domain,dc=com  
[2020-03-14 15:49:09] local.INFO: LDAP (ldap://openldap:389) - Connection: default - Operation: Search - Base DN: dc=domain,dc=com - Filter: (&(objectclass=inetorgperson)(objectclass=person)(entryuuid=1e32ea48-fa48-1039-9595-2b51f8d2ca00)) - Selected: (*,entryuuid) - Time Elapsed: 0.43
```

So, am I missing something here in the configuration, or this is the way to go?